### PR TITLE
XKCP Auto-PR revision

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -42,15 +42,15 @@ jobs:
           tar -xzvf --overwrite tmp/XKCP-win.tar.gz -C XKCP.NET/runtimes/win-x64/native/ '*.dll'
           # Commit changes
           git add -A
-          git commit -m "New version of XKCP ${{ github.event.client_payload.tag }}"
+          git commit -m "New version of StirlingLabs/XKCP ${{ github.event.client_payload.tag }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ github.token }}
-          title: 'New version of XKCP ${{ github.event.client_payload.tag }}'
+          title: 'New version of StirlingLabs/XKCP ${{ github.event.client_payload.tag }}'
           branch: check-xkcp
           body: |
-            [${{ github.event.client_payload.tag }} release of XKCP](https://github.com/StirlingLabs/XKCP/releases/tag/${{ github.event.client_payload.tag }})
+            [${{ github.event.client_payload.tag }} release of StirlingLabs/XKCP](https://github.com/StirlingLabs/XKCP/releases/tag/${{ github.event.client_payload.tag }})
           labels: |
             automated-pr
             xkcp


### PR DESCRIPTION
combine extract/copy/delete to just extract

don't take ownership of tmp dir

use github.token

try to fix PR message creation
<!-- output start -->
<details><summary>Code Coverage</summary>

&nbsp;
</details>
# Summary
|||
|:---|:---|
| Generated on: | 07/15/2021 - 09:23:09 |
| Parser: | LCovParser |
| Assemblies: | 1 |
| Classes: | 14 |
| Files: | 14 |
| Covered lines: | 53 |
| Uncovered lines: | 378 |
| Coverable lines: | 431 |
| Total lines: | 1436 |
| Line coverage: | 12.2% (53 of 431) |
| Covered branches: | 20 |
| Total branches: | 376 |
| Branch coverage: | 5.3% (20 of 376) |

|**Name**|**Covered**|**Uncovered**|**Coverable**|**Total**|**Line coverage**|**Covered**|**Total**|**Branch coverage**|
|:---|---:|---:|---:|---:|---:|---:|---:|---:|
|**Default**|**53**|**378**|**431**|**1436**|**12.2%**|**20**|**376**|**5.3%**|
|Buffers/BufferComparer.cs|0|13|13|53|0%|0|0||
|Buffers/BufferHelper.cs|0|15|15|50|0%|0|8|0%|
|Buffers/BufferOf28Bytes.cs|0|32|32|113|0%|0|18|0%|
|Buffers/BufferOf32Bytes.cs|2|30|32|112|6.2%|0|18|0%|
|Buffers/BufferOf48Bytes.cs|0|32|32|112|0%|0|18|0%|
|Buffers/BufferOf64Bytes.cs|0|32|32|112|0%|0|18|0%|
|Xkcp.cs|1|0|1|16|100%|0|0||
|Xkcp.NativeLibrary.cs|46|60|106|118|43.3%|16|88|18.1%|
|Xkcp.Sha3_224.cs|0|36|36|149|0%|0|44|0%|
|Xkcp.Sha3_256.cs|4|32|36|150|11.1%|4|44|9%|
|Xkcp.Sha3_384.cs|0|36|36|150|0%|0|44|0%|
|Xkcp.Sha3_512.cs|0|36|36|149|0%|0|44|0%|
|Xkcp.Shake128.cs|0|12|12|76|0%|0|16|0%|
|Xkcp.Shake256.cs|0|12|12|76|0%|0|16|0%|
<!-- output end -->